### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
             class="navbarContainer home-navbar-interactive"
           >
             <span class="logo">BEATSEEKER</span>
+            <button id="theme-toggle">Toggle Theme</button>
             <div data-thq="thq-navbar-nav" class="home-desktop-menu">
               <nav class="home-links">
                 <span class="bodySmall">Home</span>
@@ -452,6 +453,7 @@
         </div>
       </div>
     </div>
+    <script src="./script.js"></script>
     <script
       data-section-id="navbar"
       src="https://unpkg.com/@teleporthq/teleport-custom-scripts"

--- a/script.js
+++ b/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  const body = document.body;
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') {
+    body.classList.add('dark-mode');
+  }
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      body.classList.toggle('dark-mode');
+      const theme = body.classList.contains('dark-mode') ? 'dark' : 'light';
+      localStorage.setItem('theme', theme);
+    });
+  }
+});

--- a/style.css
+++ b/style.css
@@ -349,3 +349,13 @@
   text-transform: none;
   text-decoration: none;
 }
+body {
+  --bg-color: var(--dl-color-gray-white);
+  --text-color: var(--dl-color-gray-black);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+body.dark-mode {
+  --bg-color: var(--dl-color-gray-black);
+  --text-color: var(--dl-color-gray-white);
+}


### PR DESCRIPTION
## Summary
- implement basic dark mode toggle in `script.js`
- add theme toggle button and script reference to `index.html`
- declare color variables for light and dark modes in `style.css`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cbd73b03883318cfc05c54bf9a753